### PR TITLE
Remove 'cfn-macro-cost-rules' from IT repos

### DIFF
--- a/dependency-alerts/it-repos.json
+++ b/dependency-alerts/it-repos.json
@@ -1,5 +1,4 @@
 [
-  "Sage-Bionetworks-IT/cfn-macro-cost-rules",
   "Sage-Bionetworks-IT/cfn-cr-sc-bucket-policy",
   "Sage-Bionetworks-IT/lambda-ebs-cleanup",
   "Sage-Bionetworks-IT/lambda-template",


### PR DESCRIPTION
Remove 'cfn-macro-cost-rules' because it has been deprecated and archived